### PR TITLE
Don't have d. when there is text in death date

### DIFF
--- a/src/models/author.cpp
+++ b/src/models/author.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "author.h"
+
 Author::Author() = default;
 
 const std::string &Author::getName() const {
@@ -13,13 +14,12 @@ Author::Author(std::string name_transliterated,
                int death_hijri,
                int death_gregorian,
                std::string death_hijri_text,
-               std::string death_gregorian_text):
-    name_transliterated(std::move(name_transliterated)),
-    death_hijri(death_hijri),
-    death_gregorian(death_gregorian),
-    death_hijri_text(std::move(death_hijri_text)),
-    death_gregorian_text(std::move(death_gregorian_text))
-{
+               std::string death_gregorian_text) :
+        name_transliterated(std::move(name_transliterated)),
+        death_hijri(death_hijri),
+        death_gregorian(death_gregorian),
+        death_hijri_text(std::move(death_hijri_text)),
+        death_gregorian_text(std::move(death_gregorian_text)) {
 }
 
 int Author::getMDeathHijri() const {
@@ -37,36 +37,39 @@ const std::string &Author::getMDeathHijriText() const {
 const std::string &Author::getMDeathGregorianText() const {
     return death_gregorian_text;
 }
+
 void Author::setDeathHijri(int deathHijri) {
     death_hijri = deathHijri;
 }
+
 std::string Author::getDeathDates() const {
     std::string hijri = "NO DATA";
     std::string gregorian = "NO DATA";
 
-    if(death_hijri != 9999){
+    if (death_hijri != 9999) {
         hijri = std::to_string(death_hijri);
     }
-    if(death_hijri_text != "NO DATA")
-    {
+    if (death_hijri_text != "NO DATA") {
         hijri = death_hijri_text;
     }
 
-    if(death_gregorian != 0)
-    {
+    if (death_gregorian != 0) {
         gregorian = std::to_string(death_gregorian);
     }
-    if(death_gregorian_text != "NO DATA")
-    {
+    if (death_gregorian_text != "NO DATA") {
         gregorian = death_gregorian_text;
     }
 
-    return fmt::format("(d. {hijri}/{gregorian})",
-                       fmt::arg("hijri",hijri),
-                       fmt::arg("gregorian",gregorian)
+    if (std::isdigit(hijri[0])) {
+        return fmt::format("(d. {hijri}/{gregorian})",
+                           fmt::arg("hijri", hijri),
+                           fmt::arg("gregorian", gregorian)
+        );
+    }
+    return fmt::format("({hijri}/{gregorian})",
+                       fmt::arg("hijri", hijri),
+                       fmt::arg("gregorian", gregorian)
     );
-
-
 
 
 }

--- a/src/models/author_test.cpp
+++ b/src/models/author_test.cpp
@@ -3,7 +3,6 @@
 //
 #include <gtest/gtest.h>
 #include "author.h"
-#include <fstream>
 
 TEST(AuthorIntDeathDates, BasicTest) {
 
@@ -26,5 +25,17 @@ TEST(AuthorTextDeathDates, BasicTest) {
             "8th century",
             "14th century");
     auto expected = "(d. 8th century/14th century)";
+    EXPECT_EQ(expected, author.getDeathDates());
+}
+
+TEST(AuthorDontAddD, BasicTest) {
+
+    Author author = Author(
+            "Name Transliterated",
+            0,
+            0,
+            "fl. 553",
+            "fl. 1158");
+    auto expected = "(fl. 553/fl. 1158)";
     EXPECT_EQ(expected, author.getDeathDates());
 }


### PR DESCRIPTION
Some entries have "fl." or "alive in" in the text for the Author's date of death. Output is currently appending "d." to all dates. Needs to check if there is a text before the year, and if so, do not apply the "d."

