### PR TITLE
Only show Gregorian date where appropriate

### DIFF
--- a/src/models/edition.cpp
+++ b/src/models/edition.cpp
@@ -33,31 +33,6 @@ Edition::Edition(std::string title_transliterated,
         published_edition_of_title(std::move(published_edition_of_title)) {}
 
 std::string Edition::to_latex() {
-    auto getDates = [this]() {
-        std::string hijri = "NO DATA";
-        std::string gregorian = "NO DATA";
-
-        if (year_hijri != 0) {
-            hijri = std::to_string(year_hijri);
-
-        }
-        if (year_hijri_text != "NO DATA") {
-            hijri = year_hijri_text;
-        }
-
-        if (year_gregorian != 0) {
-            gregorian = std::to_string(year_gregorian);
-        }
-        if (year_gregorian_text != "NO DATA") {
-            gregorian = year_gregorian_text;
-        }
-
-        return fmt::format("{hijri}/{gregorian}",
-                           fmt::arg("hijri", hijri),
-                           fmt::arg("gregorian", gregorian)
-        );
-    };
-
     if (edition_type == "Modern Print") {
         return fmt::format("\\item \\emph{{{title}}}, {editor}, {publisher}, {city}, {dates}\n",
                            fmt::arg("title", title_transliterated),
@@ -76,6 +51,35 @@ std::string Edition::to_latex() {
                        fmt::arg("dates", getDates())
     );
 }
+
+std::string Edition::getDates() {
+    std::string hijri = "NO DATA";
+    std::string gregorian = "NO DATA";
+
+    if (year_hijri != 0) {
+        hijri = std::to_string(year_hijri);
+
+    }
+    if (year_hijri_text != "NO DATA") {
+        hijri = year_hijri_text;
+    }
+
+    if (year_gregorian != 0) {
+        gregorian = std::to_string(year_gregorian);
+    }
+    if (year_gregorian_text != "NO DATA") {
+        gregorian = year_gregorian_text;
+    }
+
+
+    if (year_hijri == 0 && year_gregorian != 0) {
+        return gregorian;
+    }
+    return fmt::format("{hijri}/{gregorian}",
+                       fmt::arg("hijri", hijri),
+                       fmt::arg("gregorian", gregorian)
+    );
+};
 
 std::string Edition::getPublishedEditionOfTitle() {
     return published_edition_of_title;

--- a/src/models/edition.h
+++ b/src/models/edition.h
@@ -4,6 +4,7 @@
 
 #ifndef TUB_PDF_MAKER_EDITION_H
 #define TUB_PDF_MAKER_EDITION_H
+
 #include <string>
 #include <fmt/core.h>
 
@@ -37,7 +38,9 @@ public:
             std::string published_edition_of_title);
 
     std::string to_latex();
+
     std::string getPublishedEditionOfTitle();
+
     [[nodiscard]] const std::string &getTitleTransliterated() const;
 
     [[nodiscard]] const std::string &getTitleArabic() const;
@@ -60,6 +63,7 @@ public:
 
     [[nodiscard]] const std::string &getDescription() const;
 
+    [[nodiscard]] std::string getDates();
 };
 
 

--- a/src/models/edition_test.cpp
+++ b/src/models/edition_test.cpp
@@ -13,7 +13,11 @@ TEST(EditionTestAllFields, BasicTest) {
                               "Publisher",
                               "City",
                               700,
-                              1300, "NO DATA", "NO DATA", "", "Published edition of title");
+                              1300,
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title");
 
     auto expected = "\\item \\emph{Title Transliterated}, Editor, Lithograph, Publisher, City, 700/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
@@ -28,8 +32,31 @@ TEST(EditionModernPrintTest, BasicTest) {
                               "Publisher",
                               "City",
                               700,
-                              1300, "NO DATA", "NO DATA", "", "Published edition of title");
+                              1300,
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title");
 
     auto expected = "\\item \\emph{Title Transliterated}, Editor, Publisher, City, 700/1300\n";
+    EXPECT_EQ(expected, edition.to_latex());
+}
+
+TEST(EditionOnlyShowGregorian, BasicTest) {
+
+    Edition edition = Edition("Title Transliterated",
+                              "Title Arabic",
+                              "Editor",
+                              "Modern Print",
+                              "Publisher",
+                              "City",
+                              0,
+                              1940,
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title");
+
+    auto expected = "\\item \\emph{Title Transliterated}, Editor, Publisher, City, 1940\n";
     EXPECT_EQ(expected, edition.to_latex());
 }

--- a/src/models/manuscript.cpp
+++ b/src/models/manuscript.cpp
@@ -29,40 +29,40 @@ const std::string &Manuscript::getManuscriptOfTitle() const {
 }
 
 
-std::string Manuscript::getDates() const{
+std::string Manuscript::getDates() const {
     std::string hijri = "NO DATA";
     std::string gregorian = "NO DATA";
 
-    if(year_hijri != 9999){
+    if (year_hijri != 9999) {
         hijri = std::to_string(year_hijri);
 
     }
-    if(year_hijri_text != "NO DATA")
-    {
+    if (year_hijri_text != "NO DATA") {
         hijri = year_hijri_text;
     }
 
-    if(year_gregorian != 0)
-    {
+    if (year_gregorian != 0) {
         gregorian = std::to_string(year_gregorian);
     }
-    if(year_gregorian_text != "NO DATA")
-    {
+    if (year_gregorian_text != "NO DATA") {
         gregorian = year_gregorian_text;
+    }
+    if (year_hijri == 0 && year_gregorian != 0) {
+        return gregorian;
     }
 
     return fmt::format("{hijri}/{gregorian}",
-                       fmt::arg("hijri",hijri),
-                       fmt::arg("gregorian",gregorian)
+                       fmt::arg("hijri", hijri),
+                       fmt::arg("gregorian", gregorian)
     );
 }
 
 std::string Manuscript::to_latex() const {
     return fmt::format("\\item {location}, {city} (\\#{manuscript_number}), dated {dates}\n",
-                       fmt::arg("location",location),
-                       fmt::arg("city",city),
+                       fmt::arg("location", location),
+                       fmt::arg("city", city),
                        fmt::arg("manuscript_number", manuscript_number),
-                       fmt::arg("dates",getDates()));
+                       fmt::arg("dates", getDates()));
 }
 
 const std::string &Manuscript::getLocation() const {

--- a/src/models/manuscript_test.cpp
+++ b/src/models/manuscript_test.cpp
@@ -20,3 +20,20 @@ TEST(ManuscriptTestAllFields, BasicTest) {
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 700/1300\n";
     EXPECT_EQ(expected, manuscript.to_latex());
 }
+
+TEST(ManuscriptGregorianOnly, BasicTest) {
+
+    Manuscript manuscript = Manuscript(
+            "Location",
+            0,
+            1940,
+            "NO DATA",
+            "NO DATA",
+            "City",
+            "Manuscript Number",
+            "Manuscript of Title"
+    );
+
+    auto expected = "\\item Location, City (\\#Manuscript Number), dated 1940\n";
+    EXPECT_EQ(expected, manuscript.to_latex());
+}


### PR DESCRIPTION
Some editions only have a Gregorian date, there is no need to show a Hijri or Shamsi date. Currently, if it's missing a Hijri date, the entry shows "NO DATA".

See examples below:

- Where only Gregorian date is available: 
    - Kitāb Naqd al-nathr, ed. ʻAbd al-Ḥamīd ʻAbbādī (Cairo: Lajnat al-Taʼlīf wa-l-Tarjama wa-l-Nashr, 1940)
- Where both the dates are available: 
    - Kitāb Naqd al-nathr, ed. ʻAbd al-Ḥamīd ʻAbbādī (Cairo: Lajnat al-Taʼlīf wa-l-Tarjama wa-l-Nashr, 1359/1940)