### PR TITLE
Fix output for undated manuscripts

### DIFF
--- a/src/models/manuscript.cpp
+++ b/src/models/manuscript.cpp
@@ -47,18 +47,24 @@ std::string Manuscript::getDates() const {
     if (year_gregorian_text != "NO DATA") {
         gregorian = year_gregorian_text;
     }
-    if (year_hijri == 0 && year_gregorian != 0) {
-        return gregorian;
+    if (year_hijri == 9999 && year_gregorian != 0) {
+        return fmt::format("dated {gregorian}",
+                           fmt::arg("gregorian", gregorian)
+        );
     }
 
-    return fmt::format("{hijri}/{gregorian}",
+    if (hijri == "NO DATA" && gregorian == "NO DATA") {
+        return "undated manuscript";
+    }
+
+    return fmt::format("dated {hijri}/{gregorian}",
                        fmt::arg("hijri", hijri),
                        fmt::arg("gregorian", gregorian)
     );
 }
 
 std::string Manuscript::to_latex() const {
-    return fmt::format("\\item {location}, {city} (\\#{manuscript_number}), dated {dates}\n",
+    return fmt::format("\\item {location}, {city} (\\#{manuscript_number}), {dates}\n",
                        fmt::arg("location", location),
                        fmt::arg("city", city),
                        fmt::arg("manuscript_number", manuscript_number),

--- a/src/models/manuscript_test.cpp
+++ b/src/models/manuscript_test.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #include "manuscript.h"
 
-TEST(ManuscriptTestAllFields, BasicTest) {
+TEST(Manuscript, BasicTest) {
 
     Manuscript manuscript = Manuscript(
             "Location",
@@ -21,11 +21,11 @@ TEST(ManuscriptTestAllFields, BasicTest) {
     EXPECT_EQ(expected, manuscript.to_latex());
 }
 
-TEST(ManuscriptGregorianOnly, BasicTest) {
+TEST(Manuscript, GregorianOnly) {
 
     Manuscript manuscript = Manuscript(
             "Location",
-            0,
+            9999,
             1940,
             "NO DATA",
             "NO DATA",
@@ -35,5 +35,22 @@ TEST(ManuscriptGregorianOnly, BasicTest) {
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 1940\n";
+    EXPECT_EQ(expected, manuscript.to_latex());
+}
+
+TEST(Manuscript, UndatedManuscript) {
+
+    Manuscript manuscript = Manuscript(
+            "Location",
+            9999,
+            0,
+            "NO DATA",
+            "NO DATA",
+            "City",
+            "Manuscript Number",
+            "Manuscript of Title"
+    );
+
+    auto expected = "\\item Location, City (\\#Manuscript Number), undated manuscript\n";
     EXPECT_EQ(expected, manuscript.to_latex());
 }


### PR DESCRIPTION
For manuscripts, if something is undated it should say “undated manuscript”.

