### PR TITLE
Add ed. for editor

### DIFF
--- a/src/models/edition.cpp
+++ b/src/models/edition.cpp
@@ -34,7 +34,7 @@ Edition::Edition(std::string title_transliterated,
 
 std::string Edition::to_latex() {
     if (edition_type == "Modern print") {
-        return fmt::format("\\item \\emph{{{title}}}, {editor}, {publisher}, {city}, {dates}\n",
+        return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {publisher}, {city}, {dates}\n",
                            fmt::arg("title", title_transliterated),
                            fmt::arg("editor", editor),
                            fmt::arg("publisher", publisher),
@@ -42,7 +42,7 @@ std::string Edition::to_latex() {
                            fmt::arg("dates", getDates())
         );
     }
-    return fmt::format("\\item \\emph{{{title}}}, {editor}, {edition_type}, {publisher}, {city}, {dates}\n",
+    return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {edition_type}, {publisher}, {city}, {dates}\n",
                        fmt::arg("title", title_transliterated),
                        fmt::arg("editor", editor),
                        fmt::arg("edition_type", edition_type),

--- a/src/models/edition_test.cpp
+++ b/src/models/edition_test.cpp
@@ -19,7 +19,7 @@ TEST(Edition, BasicTest) {
                               "",
                               "Published edition of title");
 
-    auto expected = "\\item \\emph{Title Transliterated}, Editor, Lithograph, Publisher, City, 700/1300\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph, Publisher, City, 700/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -38,7 +38,7 @@ TEST(Edition, ModernPrintTest) {
                               "",
                               "Published edition of title");
 
-    auto expected = "\\item \\emph{Title Transliterated}, Editor, Publisher, City, 700/1300\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 700/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -57,6 +57,6 @@ TEST(Edition, OnlyShowGregorian) {
                               "",
                               "Published edition of title");
 
-    auto expected = "\\item \\emph{Title Transliterated}, Editor, Publisher, City, 1940\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 1940\n";
     EXPECT_EQ(expected, edition.to_latex());
 }


### PR DESCRIPTION
Citing an edition requires that editors be preceded by "ed." 