### PR TITLE
Fix sort

### DIFF
--- a/src/formatters/latex_formatter_test.cpp
+++ b/src/formatters/latex_formatter_test.cpp
@@ -22,7 +22,8 @@ TEST(LatexFormatterTest, BasicTest) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
     std::vector<Manuscript> manuscripts = {manuscript};
     std::vector<CorrectionsRequired> corrections_required = {};

--- a/src/managers/entry_manager.h
+++ b/src/managers/entry_manager.h
@@ -4,6 +4,7 @@
 
 #ifndef TUB_PDF_MAKER_ENTRY_MANAGER_H
 #define TUB_PDF_MAKER_ENTRY_MANAGER_H
+
 #include "../models/entry.h"
 #include "../models/manuscript.h"
 #include <nlohmann/json.hpp>
@@ -11,27 +12,39 @@
 #include <vector>
 
 typedef std::vector<std::shared_ptr<Entry>> EntryVec;
-typedef std::map<TitleType, EntryVec > EntryMap;
+typedef std::map<TitleType, EntryVec> EntryMap;
 
 class EntryManager {
 private:
     EntryVec entries;
     EntryMap entryMap;
-    std::shared_ptr<Entry> add_entry(TubJson& json);
-    Manuscript add_manuscript(TubJson& json);
-    Edition add_edition(TubJson& json);
-    Author add_author(TubJson& json);
+
+    std::shared_ptr<Entry> add_entry(TubJson &json);
+
+    Manuscript add_manuscript(TubJson &json);
+
+    Edition add_edition(TubJson &json);
+
+    static Author add_author(TubJson &json);
 
 public:
-    void add_entries(TubJson& json);
-    void add_manuscripts(TubJson& json);
-    void add_editions(TubJson& json);
+    void add_entries(TubJson &json);
+
+    void add_manuscripts(TubJson &json);
+
+    void add_editions(TubJson &json);
+
     void add_commentaries();
-    void add_authors(TubJson& json);
-    EntryVec& getEntries();
-    EntryMap& getEntryMap();
+
+    void add_authors(TubJson &json);
+
+    EntryVec &getEntries();
+
+    EntryMap &getEntryMap();
+
     void sort_all();
 
+    static double createSort(int hijri, int gregorian, int shamsi);
 };
 
 

--- a/src/managers/entry_manager.test.cpp
+++ b/src/managers/entry_manager.test.cpp
@@ -7,8 +7,8 @@
 #include "./entry_manager.h"
 #include <iterator>
 #include <algorithm>
-class EntryBuilderTest : public ::testing::Test
-{
+
+class EntryBuilderTest : public ::testing::Test {
 protected:
     // Per-test-suite set-up.
     // Called before the first test in this test suite.
@@ -25,36 +25,38 @@ protected:
             TubJson tubJson;
             // Read from the text file
             std::ifstream file("/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/1000response.json");
-            std::string json_string( (std::istreambuf_iterator<char>(file) ),
-                                     (std::istreambuf_iterator<char>()    ) );
+            std::string json_string((std::istreambuf_iterator<char>(file)),
+                                    (std::istreambuf_iterator<char>()));
             tubJson.parse(json_string);
             auto results = tubJson.at("query").at("results");
             EntryManager entryManager;
             entryManager.add_entries(results);
 
 
-            std::ifstream fileManuscript("/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/response-manuscript.json");
-            std::string json_string_manuscript( (std::istreambuf_iterator<char>(fileManuscript) ),
-                                     (std::istreambuf_iterator<char>()    ) );
+            std::ifstream fileManuscript(
+                    "/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/response-manuscript.json");
+            std::string json_string_manuscript((std::istreambuf_iterator<char>(fileManuscript)),
+                                               (std::istreambuf_iterator<char>()));
             TubJson tubManuscriptJson;
             tubManuscriptJson.parse(json_string_manuscript);
             auto manu_results = tubManuscriptJson.at("query").at("results");
             entryManager.add_manuscripts(manu_results);
 
-            std::ifstream file_editions("/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/response-editions.json");
-            std::string json_string_editions( (std::istreambuf_iterator<char>(file_editions) ),
-                                                (std::istreambuf_iterator<char>()    ) );
+            std::ifstream file_editions(
+                    "/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/response-editions.json");
+            std::string json_string_editions((std::istreambuf_iterator<char>(file_editions)),
+                                             (std::istreambuf_iterator<char>()));
             TubJson tubEditionJson;
             tubEditionJson.parse(json_string_editions);
-            auto edition_results= tubEditionJson.at("query").at("results");
+            auto edition_results = tubEditionJson.at("query").at("results");
             entryManager.add_editions(edition_results);
 
             /*
              * Add authors
              */
             std::ifstream file_authors("/Users/pooya/Developer/sandbox/cpp/tub-tex-maker/tests/authors.json");
-            std::string json_string_authors( (std::istreambuf_iterator<char>(file_authors) ),
-                                              (std::istreambuf_iterator<char>()    ) );
+            std::string json_string_authors((std::istreambuf_iterator<char>(file_authors)),
+                                            (std::istreambuf_iterator<char>()));
             TubJson tubAuthors;
             tubAuthors.parse(json_string_authors);
             auto authors = tubAuthors.at("query").at("results");
@@ -66,17 +68,18 @@ protected:
     }
 
     // Some expensive resource shared by all tests.
-    static EntryMap& entryMap;
+    static EntryMap &entryMap;
 };
+
 EntryMap emptyMap;
-EntryMap& EntryBuilderTest::entryMap = emptyMap;
+EntryMap &EntryBuilderTest::entryMap = emptyMap;
 
 
-auto find_by_id = [](const std::vector<std::shared_ptr<Entry>>& entryMap, const std::string& id){
-    auto by_id = [&](const std::shared_ptr<Entry>& entry){
+auto find_by_id = [](const std::vector<std::shared_ptr<Entry>> &entryMap, const std::string &id) {
+    auto by_id = [&](const std::shared_ptr<Entry> &entry) {
         return entry->getId() == id;
     };
-    const auto& entryIterator = std::find_if(begin(entryMap), end(entryMap),by_id);
+    const auto &entryIterator = std::find_if(begin(entryMap), end(entryMap), by_id);
     return entryIterator->get();
 };
 
@@ -84,27 +87,28 @@ TEST_F(EntryBuilderTest, NoDatesNoDescription) {
     /*
      * Test to see if I can get a single title, and that it is in UTF-8
      */
-    Category category {ManuscriptOnly};
-    TitleType title_type {Treatise};
+    Category category{ManuscriptOnly};
+    TitleType title_type{Treatise};
     const auto entryMap = EntryBuilderTest::entryMap[title_type];
-    auto entry = find_by_id(entryMap,"(Bahth fī) uṣūl al-fiqh");
+    auto entry = find_by_id(entryMap, "(Bahth fī) uṣūl al-fiqh");
     EXPECT_EQ("بحث في) أصول الفقه)", entry->getTitleArabic());
     EXPECT_EQ("(Bahth fī) uṣūl al-fiqh", entry->getTitleTransliterated());
     EXPECT_EQ("(Bahth fī) uṣūl al-fiqh", entry->getId());
     EXPECT_EQ("NO DATA", entry->getDescription());
-    EXPECT_EQ(category,entry->getCategory());
-    EXPECT_EQ(title_type,entry->getTitleType());
+    EXPECT_EQ(category, entry->getCategory());
+    EXPECT_EQ(title_type, entry->getTitleType());
 
-    std::vector<CorrectionsRequired> correctionsRequired {CheckDates};
-    EXPECT_EQ(correctionsRequired,entry->getCorrectionsRequired());
+    std::vector<CorrectionsRequired> correctionsRequired{CheckDates};
+    EXPECT_EQ(correctionsRequired, entry->getCorrectionsRequired());
 
     EXPECT_EQ("Murtaḍā al-Ḥusaynī", entry->getAuthor().getName());
-    EXPECT_EQ(0,entry->getAuthor().getMDeathHijri());
-    EXPECT_EQ("NO DATA",entry->getAuthor().getMDeathHijriText());
-    EXPECT_EQ(0,entry->getAuthor().getMDeathGregorian());
-    EXPECT_EQ("NO DATA",entry->getAuthor().getMDeathGregorianText());
+    EXPECT_EQ(0, entry->getAuthor().getMDeathHijri());
+    EXPECT_EQ("NO DATA", entry->getAuthor().getMDeathHijriText());
+    EXPECT_EQ(0, entry->getAuthor().getMDeathGregorian());
+    EXPECT_EQ("NO DATA", entry->getAuthor().getMDeathGregorianText());
 
-    EXPECT_EQ("(d. NO DATA/NO DATA)",entry->getAuthor().getDeathDates()) << "Didn't make the correct death dates string";
+    EXPECT_EQ("(d. NO DATA/NO DATA)", entry->getAuthor().getDeathDates())
+                        << "Didn't make the correct death dates string";
 }
 
 
@@ -112,31 +116,30 @@ TEST_F(EntryBuilderTest, WithDatesAndDescription) {
     /*
      * Test to see if I can get a single title, and that it is in UTF-8
      */
-    Category category {Edited};
-    TitleType title_type {Summary};
+    Category category{Edited};
+    TitleType title_type{Summary};
     const auto entryMap = EntryBuilderTest::entryMap[title_type];
     auto entry = find_by_id(entryMap, "(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh");
-        EXPECT_EQ("مختصر) التذكرة بأصول الفقه)", entry->getTitleArabic());
-        EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh", entry->getTitleTransliterated());
-        EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh", entry->getId());
-        EXPECT_EQ( "This is a summary of al-Tadhkira bi-uṣūl al-fiqh.", entry->getDescription());
-        EXPECT_EQ(category,entry->getCategory());
-        std::vector<CorrectionsRequired> correctionsRequired {};
-        EXPECT_EQ(correctionsRequired,entry->getCorrectionsRequired());
+    EXPECT_EQ("مختصر) التذكرة بأصول الفقه)", entry->getTitleArabic());
+    EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh", entry->getTitleTransliterated());
+    EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh", entry->getId());
+    EXPECT_EQ("This is a summary of al-Tadhkira bi-uṣūl al-fiqh.", entry->getDescription());
+    EXPECT_EQ(category, entry->getCategory());
+    std::vector<CorrectionsRequired> correctionsRequired{};
+    EXPECT_EQ(correctionsRequired, entry->getCorrectionsRequired());
 
-        EXPECT_EQ(title_type,entry->getTitleType());
+    EXPECT_EQ(title_type, entry->getTitleType());
 
-        EXPECT_EQ("al-Karājukī/al-Karājakī al-Ṭarāblūsī", entry->getAuthor().getName());
-        EXPECT_EQ(449,entry->getAuthor().getMDeathHijri());
-        EXPECT_EQ("NO DATA",entry->getAuthor().getMDeathHijriText());
-        EXPECT_EQ(1057,entry->getAuthor().getMDeathGregorian());
-        EXPECT_EQ("NO DATA",entry->getAuthor().getMDeathGregorianText());
-        EXPECT_EQ("(d. 449/1057)",entry->getAuthor().getDeathDates()) << "Didn't make the correct death dates string";
+    EXPECT_EQ("al-Karājukī/al-Karājakī al-Ṭarāblūsī", entry->getAuthor().getName());
+    EXPECT_EQ(449, entry->getAuthor().getMDeathHijri());
+    EXPECT_EQ("NO DATA", entry->getAuthor().getMDeathHijriText());
+    EXPECT_EQ(1057, entry->getAuthor().getMDeathGregorian());
+    EXPECT_EQ("NO DATA", entry->getAuthor().getMDeathGregorianText());
+    EXPECT_EQ("(d. 449/1057)", entry->getAuthor().getDeathDates()) << "Didn't make the correct death dates string";
 
-        //Test manuscripts
-        EXPECT_EQ(1,entry->manuscripts.size());
-        EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh",entry->manuscripts[0].getManuscriptOfTitle());
+    //Test manuscripts
+    EXPECT_EQ(1, entry->manuscripts.size());
+    EXPECT_EQ("(Mukhtaṣar) al-Tadhkira bi-uṣul al-fiqh", entry->manuscripts[0].getManuscriptOfTitle());
 
-        EXPECT_EQ(3,entry->editions.size());
-
+    EXPECT_EQ(3, entry->editions.size());
 }

--- a/src/models/edition.cpp
+++ b/src/models/edition.cpp
@@ -19,7 +19,8 @@ Edition::Edition(std::string title_transliterated,
                  std::string year_gregorian_text,
                  std::string year_shamsi_text,
                  std::string description,
-                 std::string published_edition_of_title
+                 std::string published_edition_of_title,
+                 double sort
 ) :
         title_transliterated(std::move(title_transliterated)),
         title_arabic(std::move(title_arabic)),
@@ -34,7 +35,8 @@ Edition::Edition(std::string title_transliterated,
         year_gregorian_text(std::move(year_gregorian_text)),
         year_shamsi_text(std::move(year_shamsi_text)),
         description(std::move(description)),
-        published_edition_of_title(std::move(published_edition_of_title)) {}
+        published_edition_of_title(std::move(published_edition_of_title)),
+        sort(sort) {}
 
 std::string Edition::to_latex() {
     if (edition_type == "Modern print") {
@@ -61,7 +63,7 @@ std::string Edition::getDates() {
     std::string gregorian = "NO DATA";
     std::string shamsi = "NO DATA";
 
-    if (year_hijri != 0) {
+    if (year_hijri != 9999) {
         hijri = std::to_string(year_hijri);
 
     }
@@ -92,7 +94,7 @@ std::string Edition::getDates() {
         return fmt::format("{shamsi}Sh",
                            fmt::arg("shamsi", shamsi));
     }
-    if (year_hijri == 0 && year_gregorian != 0) {
+    if (year_hijri == 9999 && year_gregorian != 0) {
         return gregorian;
     }
 
@@ -120,5 +122,9 @@ int Edition::getYearHijri() const {
 
 const std::string &Edition::getDescription() const {
     return description;
+}
+
+double Edition::getSort() const {
+    return sort;
 }
 

--- a/src/models/edition.h
+++ b/src/models/edition.h
@@ -25,6 +25,10 @@ private:
     std::string year_shamsi_text{};
     std::string description{};
     std::string published_edition_of_title{};
+    double sort{};
+public:
+    double getSort() const;
+
 public:
     Edition(std::string title_transliterated,
             std::string title_arabic,
@@ -39,7 +43,8 @@ public:
             std::string year_gregorian_text,
             std::string year_shamsi_text,
             std::string description,
-            std::string published_edition_of_title);
+            std::string published_edition_of_title,
+            double sort);
 
     std::string to_latex();
 

--- a/src/models/edition_test.cpp
+++ b/src/models/edition_test.cpp
@@ -19,7 +19,8 @@ TEST(Edition, BasicTest) {
                               "NO DATA",
                               "NO DATA",
                               "",
-                              "Published edition of title");
+                              "Published edition of title",
+                              700);
 
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph, Publisher, City, 700/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
@@ -40,7 +41,8 @@ TEST(Edition, ModernPrintTest) {
                               "NO DATA",
                               "NO DATA",
                               "",
-                              "Published edition of title");
+                              "Published edition of title",
+                              700);
 
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 700/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
@@ -54,14 +56,15 @@ TEST(Edition, OnlyShowGregorian) {
                               "Modern print",
                               "Publisher",
                               "City",
-                              0,
+                              9999,
                               1940,
                               0,
                               "NO DATA",
                               "NO DATA",
                               "NO DATA",
                               "",
-                              "Published edition of title");
+                              "Published edition of title",
+                              700);
 
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 1940\n";
     EXPECT_EQ(expected, edition.to_latex());
@@ -75,14 +78,15 @@ TEST(Edition, Shamsi) {
                               "Modern print",
                               "Publisher",
                               "City",
-                              0,
+                              9999,
                               1300,
                               678,
                               "NO DATA",
                               "NO DATA",
                               "NO DATA",
                               "",
-                              "Published edition of title");
+                              "Published edition of title",
+                              700);
 
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 678Sh/1300\n";
     EXPECT_EQ(expected, edition.to_latex());
@@ -96,14 +100,15 @@ TEST(Edition, ShamsiOnly) {
                               "Modern print",
                               "Publisher",
                               "City",
-                              0,
+                              9999,
                               0,
                               678,
                               "NO DATA",
                               "NO DATA",
                               "NO DATA",
                               "",
-                              "Published edition of title");
+                              "Published edition of title",
+                              700);
 
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 678Sh\n";
     EXPECT_EQ(expected, edition.to_latex());

--- a/src/models/entry_test.cpp
+++ b/src/models/entry_test.cpp
@@ -24,7 +24,8 @@ TEST(EntryAllFields, BasicTest) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
     std::vector<Manuscript> manuscripts = {manuscript};
     std::vector<CorrectionsRequired> corrections_required = {};

--- a/src/models/manuscript.cpp
+++ b/src/models/manuscript.cpp
@@ -16,7 +16,8 @@ Manuscript::Manuscript(
         std::string year_shamsi_text,
         std::string city,
         std::string manuscript_number,
-        std::string manuscript_of_title) :
+        std::string manuscript_of_title,
+        double sort) :
         location(std::move(location)),
         year_hijri(year_hijri),
         year_gregorian(year_gregorian),
@@ -26,7 +27,8 @@ Manuscript::Manuscript(
         year_shamsi_text(std::move(year_shamsi_text)),
         city(std::move(city)),
         manuscript_number(std::move(manuscript_number)),
-        manuscript_of_title(std::move(manuscript_of_title)) {}
+        manuscript_of_title(std::move(manuscript_of_title)),
+        sort(sort) {}
 
 const std::string &Manuscript::getManuscriptOfTitle() const {
     return manuscript_of_title;
@@ -117,4 +119,8 @@ const std::string &Manuscript::getCity() const {
 
 const std::string &Manuscript::getManuscriptNumber() const {
     return manuscript_number;
+}
+
+double Manuscript::getSort() const {
+    return sort;
 }

--- a/src/models/manuscript.h
+++ b/src/models/manuscript.h
@@ -21,6 +21,9 @@ private:
     std::string city{};
     std::string manuscript_number{};
     std::string manuscript_of_title{};
+    double sort{};
+public:
+    double getSort() const;
 
 public:
     Manuscript();
@@ -35,7 +38,8 @@ public:
             std::string year_shamsi_text,
             std::string city,
             std::string manuscript_number,
-            std::string manuscript_of_title
+            std::string manuscript_of_title,
+            double sort
     );
 
     [[nodiscard]] const std::string &getManuscriptOfTitle() const;

--- a/src/models/manuscript_test.cpp
+++ b/src/models/manuscript_test.cpp
@@ -16,7 +16,8 @@ TEST(Manuscript, BasicTest) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 700/1300\n";
@@ -35,7 +36,8 @@ TEST(Manuscript, GregorianOnly) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 1940\n";
@@ -54,7 +56,8 @@ TEST(Manuscript, UndatedManuscript) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), undated manuscript\n";
@@ -73,7 +76,8 @@ TEST(Manuscript, ShamsiManuscirpt) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 678Sh/1300\n";
@@ -92,7 +96,8 @@ TEST(Manuscript, OnlyShamsiManuscirpt) {
             "NO DATA",
             "City",
             "Manuscript Number",
-            "Manuscript of Title"
+            "Manuscript of Title",
+            0
     );
 
     auto expected = "\\item Location, City (\\#Manuscript Number), dated 678Sh\n";


### PR DESCRIPTION
Currently all editions and manuscripts are being sorted by the Hijri date. However there are manuscripts that do not have an Hijri date, but have either a Gregorian or a Shamsi date. A new sort field needs to be created in order correctly integrate the three date types.