### PR TITLE
Add parenthesis to the edition citation

### DIFF
--- a/src/formatters/latex_formatter_test.cpp
+++ b/src/formatters/latex_formatter_test.cpp
@@ -37,7 +37,8 @@ TEST(LatexFormatterTest, BasicTest) {
             corrections_required,
             Monograph,
             "Base Text",
-            "Author Title Page");
+            "Author Title Page",
+            "");
     entry->setAuthor(author);
     entry->manuscripts = manuscripts;
 
@@ -46,6 +47,6 @@ TEST(LatexFormatterTest, BasicTest) {
 
     EntryMap entryMap = {{Monograph, monographs}};
 
-    std::string expected = " \\documentclass{article}\n    \\usepackage{fontspec,lipsum}\n    \\defaultfontfeatures{Ligatures=TeX}\n    \\usepackage[small,sf,bf]{titlesec}\n    \\setmainfont[BoldFont={Gentium Basic Bold}]{Gentium Plus}    \\newfontfamily\\arabicfont[Script=Arabic]{Amiri}\n    \\usepackage{polyglossia}\n    \\setmainlanguage{english}\n    \\setotherlanguage{arabic}\n    \\title{Twelver Usul Bibliography}\n    \\author{The TUB Team}\n    \\date{\\today} \n    \\begin{document}\n    \\maketitle\n    \\tableofcontents\n    \\pagebreak\n\\section{Monograph}\n\\begin{enumerate}\n\\item Title Transliterated\n        \\newline\n        \\textarabic{Title Arabic}\n        \\newline\n        Name Transliterated\n        \\newline\n        (d. 8th century/14th century)\n        \\newline\n        \\newline\n        \\textbf{Principal Manuscripts}\n\\begin{itemize}\n\\item Location, City (\\#Manuscript Number), dated 700/1300\n\\end{itemize}\n        \\textbf{Editions}\n\\begin{itemize}\n\\item NO DATA\n\\end{itemize}\n        \n\\end{enumerate}\n\\end{document}";
+    std::string expected = " \\documentclass{article}\n    \\usepackage{fontspec,lipsum}\n    \\defaultfontfeatures{Ligatures=TeX}\n    \\usepackage[small,sf,bf]{titlesec}\n    \\setmainfont{Gentium Plus}\n    \\newfontfamily\\arabicfont[Script=Arabic]{Amiri}\n    \\usepackage{polyglossia}\n    \\setmainlanguage{english}\n    \\setotherlanguage{arabic}\n    \\title{Twelver Usul Bibliography}\n    \\author{The TUB Team}\n    \\date{\\today} \n    \\begin{document}\n    \\maketitle\n    \\tableofcontents\n    \\pagebreak\n\\section{Monograph}\n\\begin{enumerate}\n\\item Title Transliterated\n        \\newline\n        \\textarabic{Title Arabic}\n        \\newline\n        Name Transliterated\n        \\newline\n        (d. 8th century/14th century)\n        \\newline\n        \\newline\n        \\textbf{Principal Manuscripts}\n\\begin{itemize}\n\\item Location, City (\\#Manuscript Number), dated 700/1300\n\\end{itemize}\n        \\textbf{Editions}\n\\begin{itemize}\n\\item NO DATA\n\\end{itemize}\n        \n\\end{enumerate}\n\\end{document}";
     EXPECT_EQ(expected, latex_formatter::to_latex(entryMap));
 }

--- a/src/models/edition.cpp
+++ b/src/models/edition.cpp
@@ -40,7 +40,7 @@ Edition::Edition(std::string title_transliterated,
 
 std::string Edition::to_latex() {
     if (edition_type == "Modern print") {
-        return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {publisher}, {city}, {dates}\n",
+        return fmt::format("\\item \\emph{{{title}}}, ed. {editor} ({city}: {publisher}, {dates})\n",
                            fmt::arg("title", title_transliterated),
                            fmt::arg("editor", editor),
                            fmt::arg("publisher", publisher),
@@ -48,7 +48,7 @@ std::string Edition::to_latex() {
                            fmt::arg("dates", getDates())
         );
     }
-    return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {edition_type}, {publisher}, {city}, {dates}\n",
+    return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {edition_type} ({city}: {publisher}, {dates})\n",
                        fmt::arg("title", title_transliterated),
                        fmt::arg("editor", editor),
                        fmt::arg("edition_type", edition_type),

--- a/src/models/edition_test.cpp
+++ b/src/models/edition_test.cpp
@@ -22,7 +22,7 @@ TEST(Edition, BasicTest) {
                               "Published edition of title",
                               700);
 
-    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph, Publisher, City, 700/1300\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph (City: Publisher, 700/1300)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -44,7 +44,7 @@ TEST(Edition, ModernPrintTest) {
                               "Published edition of title",
                               700);
 
-    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 700/1300\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor (City: Publisher, 700/1300)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -66,7 +66,7 @@ TEST(Edition, OnlyShowGregorian) {
                               "Published edition of title",
                               700);
 
-    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 1940\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor (City: Publisher, 1940)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -88,7 +88,7 @@ TEST(Edition, Shamsi) {
                               "Published edition of title",
                               700);
 
-    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 678Sh/1300\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor (City: Publisher, 678Sh/1300)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
 
@@ -110,6 +110,6 @@ TEST(Edition, ShamsiOnly) {
                               "Published edition of title",
                               700);
 
-    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Publisher, City, 678Sh\n";
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor (City: Publisher, 678Sh)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }

--- a/src/models/entry_test.cpp
+++ b/src/models/entry_test.cpp
@@ -39,7 +39,8 @@ TEST(EntryAllFields, BasicTest) {
             corrections_required,
             Monograph,
             "Base Text",
-            "Author Title Page");
+            "Author Title Page",
+            "");
     entry.setAuthor(author);
     entry.manuscripts = manuscripts;
 


### PR DESCRIPTION
We need parenthesis for editions:

Kitāb Naqd al-nathr, ed. ʻAbd al-Ḥamīd ʻAbbādī (Cairo: Lajnat al-Taʼlīf wa-l-Tarjama wa-l-Nashr, 1940)

Kitāb Naqd al-nathr, ed. ʻAbd al-Ḥamīd ʻAbbādī (Cairo: Lajnat al-Taʼlīf wa-l-Tarjama wa-l-Nashr, 1359/1940) 

Kitāb Naqd al-nathr, ed. ʻAbd al-Ḥamīd ʻAbbādī (Cairo: Lajnat al-Taʼlīf wa-l-Tarjama wa-l-Nashr, 1359Sh/1940)