### PR TITLE
Remove fields which have no data

### DIFF
--- a/src/formatters/latex_formatter.cpp
+++ b/src/formatters/latex_formatter.cpp
@@ -69,3 +69,10 @@ std::string latex_formatter::to_latex(const EntryMap &entryMap) {
     final += "\\end{document}";
     return final;
 }
+
+std::string parse_field(const std::string &field) {
+    if (field == "NO DATA") {
+        return "";
+    }
+    return field + ",";
+}

--- a/src/formatters/latex_formatter.h
+++ b/src/formatters/latex_formatter.h
@@ -10,5 +10,9 @@
 
 namespace latex_formatter {
     std::string to_latex(const EntryMap &entryMap);
+
+    std::string parse_field(std::string field);
+
+    std::string parse_field(int field);
 }
 #endif //TUB_PDF_MAKER_LATEX_FORMATTER_H

--- a/src/models/edition.cpp
+++ b/src/models/edition.cpp
@@ -39,23 +39,27 @@ Edition::Edition(std::string title_transliterated,
         sort(sort) {}
 
 std::string Edition::to_latex() {
-    if (edition_type == "Modern print") {
-        return fmt::format("\\item \\emph{{{title}}}, ed. {editor} ({city}: {publisher}, {dates})\n",
-                           fmt::arg("title", title_transliterated),
-                           fmt::arg("editor", editor),
-                           fmt::arg("publisher", publisher),
-                           fmt::arg("city", city),
-                           fmt::arg("dates", getDates())
-        );
-    }
-    return fmt::format("\\item \\emph{{{title}}}, ed. {editor}, {edition_type} ({city}: {publisher}, {dates})\n",
+    return fmt::format("\\item \\emph{{{title}}}{editor}{edition_type} ({city} {publisher}, {dates})\n",
                        fmt::arg("title", title_transliterated),
-                       fmt::arg("editor", editor),
-                       fmt::arg("edition_type", edition_type),
-                       fmt::arg("publisher", publisher),
-                       fmt::arg("city", city),
+                       fmt::arg("editor", Edition::create_tex(editor, f_editor)),
+                       fmt::arg("edition_type", create_tex(edition_type, f_edition_type)),
+                       fmt::arg("publisher", Edition::create_tex(publisher, f_publisher)),
+                       fmt::arg("city", Edition::create_tex(city, f_city)),
                        fmt::arg("dates", getDates())
     );
+}
+
+std::string Edition::create_tex(const std::string &value, Field field) {
+    switch (field) {
+        case f_editor:
+            return (value == "NO DATA") ? "" : ", ed. " + value;
+        case f_edition_type:
+            return (value == "Modern print") ? "" : ", " + value;
+        case f_city:
+            return (value == "NO DATA") ? "n.plac.," : value + ":";
+        case f_publisher:
+            return (value == "NO DATA") ? "n.pub." : value;
+    }
 }
 
 std::string Edition::getDates() {
@@ -114,10 +118,6 @@ const std::string &Edition::getTitleTransliterated() const {
 
 const std::string &Edition::getTitleArabic() const {
     return title_arabic;
-}
-
-int Edition::getYearHijri() const {
-    return year_hijri;
 }
 
 const std::string &Edition::getDescription() const {

--- a/src/models/edition.h
+++ b/src/models/edition.h
@@ -8,6 +8,10 @@
 #include <string>
 #include <fmt/core.h>
 
+enum Field {
+    f_editor, f_edition_type, f_publisher, f_city
+};
+
 class Edition {
 
 private:
@@ -26,8 +30,8 @@ private:
     std::string description{};
     std::string published_edition_of_title{};
     double sort{};
-public:
-    double getSort() const;
+
+    static std::string create_tex(const std::string &value, Field field);
 
 public:
     Edition(std::string title_transliterated,
@@ -54,26 +58,12 @@ public:
 
     [[nodiscard]] const std::string &getTitleArabic() const;
 
-    [[nodiscard]] const std::string &getEditor() const;
-
-    [[nodiscard]] const std::string &getEditionType() const;
-
-    [[nodiscard]] const std::string &getPublisher() const;
-
-    [[nodiscard]] const std::string &getCity() const;
-
-    [[nodiscard]] int getYearHijri() const;
-
-    [[nodiscard]] int getYearGregorian() const;
-
-    [[nodiscard]] const std::string &getYearHijriText() const;
-
-    [[nodiscard]] const std::string &getYearGregorianText() const;
-
     [[nodiscard]] const std::string &getDescription() const;
 
     [[nodiscard]] std::string getDates();
-};
 
+    [[nodiscard]] double getSort() const;
+
+};
 
 #endif //TUB_PDF_MAKER_EDITION_H

--- a/src/models/edition_test.cpp
+++ b/src/models/edition_test.cpp
@@ -113,3 +113,69 @@ TEST(Edition, ShamsiOnly) {
     auto expected = "\\item \\emph{Title Transliterated}, ed. Editor (City: Publisher, 678Sh)\n";
     EXPECT_EQ(expected, edition.to_latex());
 }
+
+TEST(Edition, NoPublisher) {
+
+    Edition edition = Edition("Title Transliterated",
+                              "Title Arabic",
+                              "Editor",
+                              "Lithograph",
+                              "NO DATA",
+                              "City",
+                              700,
+                              1300,
+                              0,
+                              "NO DATA",
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title",
+                              700);
+
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph (City: n.pub., 700/1300)\n";
+    EXPECT_EQ(expected, edition.to_latex());
+}
+
+TEST(Edition, NoCity) {
+
+    Edition edition = Edition("Title Transliterated",
+                              "Title Arabic",
+                              "Editor",
+                              "Lithograph",
+                              "Publisher",
+                              "NO DATA",
+                              700,
+                              1300,
+                              0,
+                              "NO DATA",
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title",
+                              700);
+
+    auto expected = "\\item \\emph{Title Transliterated}, ed. Editor, Lithograph (n.plac., Publisher, 700/1300)\n";
+    EXPECT_EQ(expected, edition.to_latex());
+}
+
+TEST(Edition, NoEditorModernPrint) {
+
+    Edition edition = Edition("Title Transliterated",
+                              "Title Arabic",
+                              "NO DATA",
+                              "Modern print",
+                              "Publisher",
+                              "City",
+                              700,
+                              1300,
+                              0,
+                              "NO DATA",
+                              "NO DATA",
+                              "NO DATA",
+                              "",
+                              "Published edition of title",
+                              700);
+
+    auto expected = "\\item \\emph{Title Transliterated} (City: Publisher, 700/1300)\n";
+    EXPECT_EQ(expected, edition.to_latex());
+}


### PR DESCRIPTION
When I spoke with Rob last time we decided that we get rid of NO DATA. For instance, in the following cases if we get rid of NO DATA it would read clearer. Please see below what currently appears and what ideally we would like to see.


• al-Burhān fī wujūh al-bayān, ed. NO DATA, NO DATA, NO DATA, NO DATA, 1930

This should appear as: al-Burhān fī wujūh al-bayān (n. plac., n.pub., 1930)

• al-Burhān fī wujūh al-bayān, ed. ʿAbd al-Ḥamīd ʿIbādī, NO DATA, NO DATA, 1938

This should appear as: al-Burhān fī wujūh al-bayān, ed. ʿAbd al-Ḥamīd ʿIbādī (n. plac., n.pub., 1938)

• Kitāb Naqd al-nathr, ed. NO DATA, Dār al-Kutub al-ʿIlmiyya, Beirut, 1980

This should appear as: Kitāb Naqd al-nathr (Beirut: Dār al-Kutub al-ʿIlmiyya, 1980)

• KitābNaqdal-nathr, ed. NO DATA, Dār al-Maʻārif lil-Ṭibāʻa wa-l-Nashr, Sousse, 2004

This should appear as: Kitāb Naqd al-nathr (Sousse: Dār al-Maʻārif lil-Ṭibāʻa wa-l-Nashr, 2004)
