### PR TITLE
Add "d." to dates that say "after"

### DIFF
--- a/src/models/author.cpp
+++ b/src/models/author.cpp
@@ -66,6 +66,12 @@ std::string Author::getDeathDates() const {
                            fmt::arg("gregorian", gregorian)
         );
     }
+    if (hijri.substr(0, 5) == "after") {
+        return fmt::format("(d. {hijri}/d. {gregorian})",
+                           fmt::arg("hijri", hijri),
+                           fmt::arg("gregorian", gregorian)
+        );
+    }
     return fmt::format("({hijri}/{gregorian})",
                        fmt::arg("hijri", hijri),
                        fmt::arg("gregorian", gregorian)

--- a/src/models/author_test.cpp
+++ b/src/models/author_test.cpp
@@ -4,7 +4,19 @@
 #include <gtest/gtest.h>
 #include "author.h"
 
-TEST(AuthorIntDeathDates, BasicTest) {
+TEST(Author, IntAndTextDates) {
+
+    Author author = Author(
+            "Name Transliterated",
+            700,
+            1300,
+            "8th century",
+            "14th century");
+    auto expected = "(d. 8th century/14th century)";
+    EXPECT_EQ(expected, author.getDeathDates());
+}
+
+TEST(Author, IntDatesOnly) {
 
     Author author = Author(
             "Name Transliterated",
@@ -16,7 +28,7 @@ TEST(AuthorIntDeathDates, BasicTest) {
     EXPECT_EQ(expected, author.getDeathDates());
 }
 
-TEST(AuthorTextDeathDates, BasicTest) {
+TEST(Author, NoIntDates) {
 
     Author author = Author(
             "Name Transliterated",
@@ -28,7 +40,7 @@ TEST(AuthorTextDeathDates, BasicTest) {
     EXPECT_EQ(expected, author.getDeathDates());
 }
 
-TEST(AuthorDontAddD, BasicTest) {
+TEST(Author, DontAddD) {
 
     Author author = Author(
             "Name Transliterated",
@@ -37,5 +49,17 @@ TEST(AuthorDontAddD, BasicTest) {
             "fl. 553",
             "fl. 1158");
     auto expected = "(fl. 553/fl. 1158)";
+    EXPECT_EQ(expected, author.getDeathDates());
+}
+
+TEST(Author, After) {
+
+    Author author = Author(
+            "Name Transliterated",
+            0,
+            0,
+            "after 1129",
+            "after 1716");
+    auto expected = "(d. after 1129/d. after 1716)";
     EXPECT_EQ(expected, author.getDeathDates());
 }


### PR DESCRIPTION
The formula that "d." should not appear when there is text in the dates would not apply when the text is "after 1129/after 1716". Here we want "d. after 1129/after 1716". 