### PR TITLE
Remove "Editions" section for all title types that are not Edited titles

### DIFF
--- a/src/models/entry.cpp
+++ b/src/models/entry.cpp
@@ -57,18 +57,21 @@ std::string Entry::to_latex() {
      * Create edition subsection
      */
     auto editions_to_latex = [this]() {
-        std::string edition_latex = "\\textbf{Editions}\n\\begin{itemize}\n";
-        if (editions.empty()) {
-            edition_latex += "\\item NO DATA\n";
+        if (category == Edited) {
+            std::string edition_latex = "\\textbf{Editions}\n\\begin{itemize}\n";
+            if (editions.empty()) {
+                edition_latex += "\\item NO DATA\n";
 
-        } else {
-            for (auto &edition: this->editions) {
-                edition_latex += edition.to_latex();
+            } else {
+                for (auto &edition: this->editions) {
+                    edition_latex += edition.to_latex();
+                }
             }
-        }
 
-        edition_latex += "\\end{itemize}\n";
-        return edition_latex;
+            edition_latex += "\\end{itemize}\n";
+            return edition_latex;
+        }
+        return std::string();
     };
 
     /*

--- a/src/models/entry_test.cpp
+++ b/src/models/entry_test.cpp
@@ -6,7 +6,7 @@
 #include "author.h"
 #include "manuscript.h"
 
-TEST(EntryAllFields, BasicTest) {
+TEST(Entry, BasicTest) {
 
     Author author = Author(
             "Name Transliterated",
@@ -45,5 +45,47 @@ TEST(EntryAllFields, BasicTest) {
     entry.manuscripts = manuscripts;
 
     auto expected = "\\item Title Transliterated\n        \\newline\n        \\textarabic{Title Arabic}\n        \\newline\n        Name Transliterated\n        \\newline\n        (d. 8th century/14th century)\n        \\newline\n        \\newline\n        \\textbf{Principal Manuscripts}\n\\begin{itemize}\n\\item Location, City (\\#Manuscript Number), dated 700/1300\n\\end{itemize}\n        \\textbf{Editions}\n\\begin{itemize}\n\\item NO DATA\n\\end{itemize}\n        \n";
+    EXPECT_EQ(expected, entry.to_latex());
+}
+
+TEST(Entry, ManuscriptOnly) {
+
+    Author author = Author(
+            "Name Transliterated",
+            0,
+            0,
+            "8th century",
+            "14th century");
+    Manuscript manuscript = Manuscript(
+            "Location",
+            700,
+            1300,
+            0,
+            "NO DATA",
+            "NO DATA",
+            "NO DATA",
+            "City",
+            "Manuscript Number",
+            "Manuscript of Title",
+            0
+    );
+    std::vector<Manuscript> manuscripts = {manuscript};
+    std::vector<CorrectionsRequired> corrections_required = {};
+
+    Entry entry = Entry(
+            "1",
+            "Title Transliterated",
+            "Title Arabic",
+            "Description",
+            ManuscriptOnly,
+            corrections_required,
+            Monograph,
+            "Base Text",
+            "Author Title Page",
+            "");
+    entry.setAuthor(author);
+    entry.manuscripts = manuscripts;
+
+    auto expected = "\\item Title Transliterated\n        \\newline\n        \\textarabic{Title Arabic}\n        \\newline\n        Name Transliterated\n        \\newline\n        (d. 8th century/14th century)\n        \\newline\n        \\newline\n        \\textbf{Principal Manuscripts}\n\\begin{itemize}\n\\item Location, City (\\#Manuscript Number), dated 700/1300\n\\end{itemize}\n                \n";
     EXPECT_EQ(expected, entry.to_latex());
 }


### PR DESCRIPTION
Currently, all title types show an Edition section, even though only Edited titles will have editions. Manuscript-only and Non-extant titles do not have editions.